### PR TITLE
Fix gesture recognizer type mismatch

### DIFF
--- a/3DBall/GameViewController.swift
+++ b/3DBall/GameViewController.swift
@@ -85,7 +85,8 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate {
         }
     }
 
-    @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+    // Accept any gesture recognizer so the method can be reused for taps and swipes
+    @objc func handleTap(_ gesture: UIGestureRecognizer) {
         ballNode.jump()
     }
 


### PR DESCRIPTION
## Summary
- allow `handleTap` to accept any gesture type

## Testing
- `swiftc 3DBall/*.swift` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6857e07a1da4832891a6537f1581dd92