### PR TITLE
Add start screen with high score

### DIFF
--- a/3DBall/AppDelegate.swift
+++ b/3DBall/AppDelegate.swift
@@ -14,7 +14,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        window = UIWindow(frame: UIScreen.main.bounds)
+        window?.rootViewController = StartViewController()
+        window?.makeKeyAndVisible()
         return true
     }
 

--- a/3DBall/GameViewController.swift
+++ b/3DBall/GameViewController.swift
@@ -17,6 +17,9 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate {
     var scene: SCNScene!
     var groundManager: GroundManager!
     var obstacleManager: ObstacleManager!
+    weak var gameDelegate: GameViewControllerDelegate?
+    private var timer: Timer?
+    private var currentScore: Int = 0
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -37,7 +40,7 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate {
         setupGestures()
         
         // Timer to update game state (apply movement, update ground and obstacles)
-        Timer.scheduledTimer(timeInterval: 0.02, target: self, selector: #selector(updateGame), userInfo: nil, repeats: true)
+        timer = Timer.scheduledTimer(timeInterval: 0.02, target: self, selector: #selector(updateGame), userInfo: nil, repeats: true)
     }
 
     func setupCamera() {
@@ -95,6 +98,8 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate {
         cameraNode.position.z = ballNode.presentation.position.z + 10
         cameraNode.look(at: ballNode.presentation.position)
 
+        currentScore = max(currentScore, Int(-ballNode.presentation.position.z))
+
         // Prevent the ball from sinking below the ground level
         let minY: Float = 0.5
         if ballNode.presentation.position.y < minY {
@@ -111,6 +116,7 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate {
     }
 
     func physicsWorld(_ world: SCNPhysicsWorld, didBegin contact: SCNPhysicsContact) {
-        print("Collision detected!")
+        timer?.invalidate()
+        gameDelegate?.gameViewController(self, didEndGameWithScore: currentScore)
     }
 }

--- a/3DBall/StartViewController.swift
+++ b/3DBall/StartViewController.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+protocol GameViewControllerDelegate: AnyObject {
+    func gameViewController(_ controller: GameViewController, didEndGameWithScore score: Int)
+}
+
+class StartViewController: UIViewController, GameViewControllerDelegate {
+
+    private let highScoreLabel = UILabel()
+    private let startButton = UIButton(type: .system)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setupUI()
+        updateHighScoreLabel()
+    }
+
+    private func setupUI() {
+        highScoreLabel.translatesAutoresizingMaskIntoConstraints = false
+        startButton.translatesAutoresizingMaskIntoConstraints = false
+
+        highScoreLabel.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        highScoreLabel.textAlignment = .center
+
+        startButton.setTitle("Start", for: .normal)
+        startButton.titleLabel?.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        startButton.addTarget(self, action: #selector(startGame), for: .touchUpInside)
+
+        view.addSubview(highScoreLabel)
+        view.addSubview(startButton)
+
+        NSLayoutConstraint.activate([
+            highScoreLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            highScoreLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -40),
+            startButton.topAnchor.constraint(equalTo: highScoreLabel.bottomAnchor, constant: 20),
+            startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+    }
+
+    private func updateHighScoreLabel() {
+        let highScore = UserDefaults.standard.integer(forKey: "HighScore")
+        highScoreLabel.text = "High Score: \(highScore)"
+    }
+
+    @objc private func startGame() {
+        let gameVC = GameViewController()
+        gameVC.gameDelegate = self
+        gameVC.modalPresentationStyle = .fullScreen
+        present(gameVC, animated: true)
+    }
+
+    // MARK: - GameViewControllerDelegate
+    func gameViewController(_ controller: GameViewController, didEndGameWithScore score: Int) {
+        let currentHigh = UserDefaults.standard.integer(forKey: "HighScore")
+        if score > currentHigh {
+            UserDefaults.standard.set(score, forKey: "HighScore")
+        }
+        dismiss(animated: true) { [weak self] in
+            self?.updateHighScoreLabel()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `StartViewController` with a high score label and start button
- show the start screen on app launch via `AppDelegate`
- track score in `GameViewController` and notify `StartViewController` when the game ends

## Testing
- `swiftc 3DBall/*.swift -o GameApp` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6857e8636f6883289c69de75a048a731