### PR TITLE
Enhance obstacle variety

### DIFF
--- a/3DBall/ObstacleManager.swift
+++ b/3DBall/ObstacleManager.swift
@@ -8,6 +8,36 @@
 
 import SceneKit
 
+/// Different obstacle shapes that can appear in the scene
+private enum ObstacleType: CaseIterable {
+    case cylinder
+    case sphere
+    case pyramid
+    case torus
+
+    /// Create a geometry for the obstacle along with a distinctive color
+    func geometry() -> SCNGeometry {
+        let geometry: SCNGeometry
+        let material = SCNMaterial()
+        switch self {
+        case .cylinder:
+            geometry = SCNCylinder(radius: 0.4, height: 1.0)
+            material.diffuse.contents = UIColor.systemBlue
+        case .sphere:
+            geometry = SCNSphere(radius: 0.5)
+            material.diffuse.contents = UIColor.systemYellow
+        case .pyramid:
+            geometry = SCNPyramid(width: 1.0, height: 1.0, length: 1.0)
+            material.diffuse.contents = UIColor.systemGreen
+        case .torus:
+            geometry = SCNTorus(ringRadius: 0.6, pipeRadius: 0.2)
+            material.diffuse.contents = UIColor.systemPurple
+        }
+        geometry.firstMaterial = material
+        return geometry
+    }
+}
+
 class ObstacleManager {
     private var scene: SCNScene
     private var obstacles: [SCNNode] = []
@@ -18,14 +48,13 @@ class ObstacleManager {
     }
 
     func spawnObstacle(atZ z: Float) {
-        guard let lane = lanes.randomElement() else { return }
+        guard
+            let lane = lanes.randomElement(),
+            let type = ObstacleType.allCases.randomElement()
+        else { return }
 
-        let box = SCNBox(width: 0.8, height: 1.0, length: 0.8, chamferRadius: 0.1)
-        let material = SCNMaterial()
-        material.diffuse.contents = UIColor.red
-        box.firstMaterial = material
-
-        let obstacle = SCNNode(geometry: box)
+        let obstacleGeometry = type.geometry()
+        let obstacle = SCNNode(geometry: obstacleGeometry)
         obstacle.position = SCNVector3(lane, 0.6, z)
         obstacle.physicsBody = SCNPhysicsBody(type: .kinematic, shape: nil)
         obstacle.physicsBody?.categoryBitMask = 2


### PR DESCRIPTION
## Summary
- use an enum to define multiple obstacle shapes
- spawn random shapes instead of a single red box

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857eea25ccc832882eb9cde72a2151a