### PR TITLE
Add sloped ground tiles

### DIFF
--- a/3DBall/GroundManager.swift
+++ b/3DBall/GroundManager.swift
@@ -7,9 +7,28 @@
 
 import SceneKit
 
+/// Different styles for ground tiles. A tile can be flat or sloped
+/// upwards or downwards like a slide. The slide angles are subtle so the
+/// ball can smoothly roll over them.
+private enum GroundStyle: CaseIterable {
+    case flat
+    case slideUp
+    case slideDown
+
+    /// Corresponding tilt angle for each ground style
+    var angle: Float {
+        switch self {
+        case .flat:      return 0
+        case .slideUp:   return .pi / 12  // ~15 degrees
+        case .slideDown: return -.pi / 12
+        }
+    }
+}
+
 class GroundManager {
 
     private(set) var tiles: [SCNNode] = []
+    private let material: SCNMaterial
 
     init(scene: SCNScene) {
         let material = SCNMaterial()
@@ -21,15 +40,13 @@ class GroundManager {
         } else {
             material.diffuse.contents = UIColor.darkGray
         }
+        self.material = material
 
         for i in 0..<5 {
-            let ground = SCNBox(width: 10, height: 0.2, length: 20, chamferRadius: 0)
-            ground.materials = [material]
-            let groundNode = SCNNode(geometry: ground)
-            groundNode.position = SCNVector3(0, 0, -Float(i) * 20)
-            groundNode.physicsBody = SCNPhysicsBody.static()
-            scene.rootNode.addChildNode(groundNode)
-            tiles.append(groundNode)
+            let tile = createTile(style: GroundStyle.allCases.randomElement()!)
+            tile.position = SCNVector3(0, 0, -Float(i) * 20)
+            scene.rootNode.addChildNode(tile)
+            tiles.append(tile)
         }
     }
 
@@ -37,7 +54,22 @@ class GroundManager {
         for tile in tiles {
             if tile.position.z - playerZ > 30 {
                 tile.position.z -= 100
+                configure(tile, style: GroundStyle.allCases.randomElement()!)
             }
         }
+    }
+
+    private func createTile(style: GroundStyle) -> SCNNode {
+        let ground = SCNBox(width: 10, height: 0.2, length: 20, chamferRadius: 0)
+        ground.materials = [material]
+        let node = SCNNode(geometry: ground)
+        node.physicsBody = SCNPhysicsBody.static()
+        configure(node, style: style)
+        return node
+    }
+
+    private func configure(_ tile: SCNNode, style: GroundStyle) {
+        tile.eulerAngles.x = style.angle
+        tile.position.y = 0
     }
 }


### PR DESCRIPTION
## Summary
- add a `GroundStyle` enum with flat and slide options
- randomly assign a style to each ground segment when it is created or recycled

## Testing
- `swiftc 3DBall/*.swift -o /tmp/app` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6857f5488fa48328bd6748113308357b