### PR TITLE
Restore simple ground tiles

### DIFF
--- a/3DBall/GroundManager.swift
+++ b/3DBall/GroundManager.swift
@@ -7,40 +7,13 @@
 
 import SceneKit
 
-/// Different styles for ground tiles. A tile can be flat or sloped
-/// upwards or downwards like a slide. The slide angles are subtle so the
-/// ball can smoothly roll over them.
-private enum GroundStyle: CaseIterable {
-    case flat
-    case slideUp
-    case slideDown
-
-    /// Corresponding tilt angle for each ground style
-    var angle: Float {
-        switch self {
-        case .flat:      return 0
-        case .slideUp:   return .pi / 12  // ~15 degrees
-        case .slideDown: return -.pi / 12
-        }
-    }
-
-    /// Difference in height between the front and back of the tile
-    var heightDelta: Float {
-        return 20 * sin(angle)
-    }
-}
-
 class GroundManager {
 
     private(set) var tiles: [SCNNode] = []
-    private let material: SCNMaterial
-    private let tileLength: Float = 20
-    private var nextSpawnZ: Float = 0
-    private var nextStartHeight: Float = 0
 
     init(scene: SCNScene) {
         let material = SCNMaterial()
-        if let image = UIImage(named: "ground") {
+        if let image = UIImage(named: "art.scnassets/texture.png") {
             material.diffuse.contents = image
             material.diffuse.wrapS = .repeat
             material.diffuse.wrapT = .repeat
@@ -48,47 +21,23 @@ class GroundManager {
         } else {
             material.diffuse.contents = UIColor.darkGray
         }
-        self.material = material
 
-        var startHeight: Float = 0
-        var spawnZ: Float = 0
-        for _ in 0..<5 {
-            let style = GroundStyle.allCases.randomElement()!
-            let tile = createTile(style: style)
-            tile.position.z = spawnZ
-            configure(tile, style: style, startHeight: startHeight)
-            scene.rootNode.addChildNode(tile)
-            tiles.append(tile)
-            spawnZ -= tileLength
-            startHeight += style.heightDelta
+        for i in 0..<5 {
+            let ground = SCNBox(width: 10, height: 0.2, length: 20, chamferRadius: 0)
+            ground.materials = [material]
+            let groundNode = SCNNode(geometry: ground)
+            groundNode.position = SCNVector3(0, 0, -Float(i) * 20)
+            groundNode.physicsBody = SCNPhysicsBody.static()
+            scene.rootNode.addChildNode(groundNode)
+            tiles.append(groundNode)
         }
-        nextSpawnZ = spawnZ
-        nextStartHeight = startHeight
     }
 
     func update(for playerZ: Float) {
         for tile in tiles {
             if tile.position.z - playerZ > 30 {
-                let style = GroundStyle.allCases.randomElement()!
-                tile.position.z = nextSpawnZ
-                configure(tile, style: style, startHeight: nextStartHeight)
-                nextSpawnZ -= tileLength
-                nextStartHeight += style.heightDelta
+                tile.position.z -= 100
             }
         }
-    }
-
-    private func createTile(style: GroundStyle) -> SCNNode {
-        let ground = SCNBox(width: 10, height: 0.2, length: 20, chamferRadius: 0)
-        ground.materials = [material]
-        let node = SCNNode(geometry: ground)
-        node.physicsBody = SCNPhysicsBody.static()
-        configure(node, style: style, startHeight: 0)
-        return node
-    }
-
-    private func configure(_ tile: SCNNode, style: GroundStyle, startHeight: Float) {
-        tile.eulerAngles.x = style.angle
-        tile.position.y = startHeight + 10 * sin(style.angle)
     }
 }


### PR DESCRIPTION
## Summary
- revert `GroundManager` to earlier implementation using five straight ground tiles textured with `texture.png`

## Testing
- `swift --version`
- `xcodebuild -list -project 3DBall.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857fbfbe53c83289cdda0c20004a0ed