### PR TITLE
Fix ball speed and lane move

### DIFF
--- a/3DBall/GameViewController.swift
+++ b/3DBall/GameViewController.swift
@@ -99,19 +99,19 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate {
     }
 
     @objc func updateGame() {
-        // Apply a stronger constant forward force so the ball gains
-        // speed more quickly. The previous value (-1) resulted in slow
-        // acceleration causing the ball to spin without translating
-        // noticeably on the ground.
-        ballNode.physicsBody?.applyForce(SCNVector3(0, 0, -1), asImpulse: false)
-
-        // Allow a higher forward speed before clamping so the game
-        // feels more responsive and matches the fast rolling motion
-        // of the ball.
+        // Gradually accelerate the ball to a target speed to avoid
+        // velocity growing without bound. Directly manipulating the
+        // velocity rather than continuously applying a force yields a
+        // smoother result.
         if var velocity = ballNode.physicsBody?.velocity {
-            let maxForwardSpeed: Float = -40
-            if velocity.z < maxForwardSpeed {
-                velocity.z = maxForwardSpeed
+            let targetSpeed: Float = -20
+            let acceleration: Float = -0.6
+
+            if velocity.z > targetSpeed {
+                velocity.z += acceleration
+                if velocity.z < targetSpeed {
+                    velocity.z = targetSpeed
+                }
                 ballNode.physicsBody?.velocity = velocity
             }
         }

--- a/3DBall/PlayerNode.swift
+++ b/3DBall/PlayerNode.swift
@@ -88,7 +88,12 @@ class PlayerNode: SCNNode {
         // After the animation completes, update the actual position so the
         // physics body stays in sync with the node.
         let sync = SCNAction.run { [weak self] _ in
-            self?.position = target
+            guard let self = self else { return }
+            self.position = target
+            if var velocity = self.physicsBody?.velocity {
+                velocity.x = 0
+                self.physicsBody?.velocity = velocity
+            }
         }
 
         let sequence = SCNAction.sequence([move, sync])


### PR DESCRIPTION
## Summary
- smooth out forward acceleration and clamp to a target speed
- reset lateral velocity after lane changes

## Testing
- `swiftc -o /tmp/test 3DBall/GameViewController.swift 3DBall/PlayerNode.swift 3DBall/GroundManager.swift 3DBall/ObstacleManager.swift 3DBall/EnvironmentManager.swift 3DBall/StartViewController.swift` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6858067f20d88328bc36bd5898dfc54f