### PR TITLE
Fix excessive rolling in 3DBall

### DIFF
--- a/3DBall/GameViewController.swift
+++ b/3DBall/GameViewController.swift
@@ -113,6 +113,12 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate {
                     velocity.z = targetSpeed
                 }
                 ballNode.physicsBody?.velocity = velocity
+                // Match the angular velocity to the linear speed so the
+                // sphere rolls without sliding. This prevents friction from
+                // continuously increasing the spin rate.
+                let radius: Float = 0.5
+                let angularSpeed = velocity.z / radius
+                ballNode.physicsBody?.angularVelocity = SCNVector4(1, 0, 0, angularSpeed)
             }
         }
         cameraNode.position.z = ballNode.presentation.position.z + 10


### PR DESCRIPTION
## Summary
- sync the ball's angular velocity with its forward velocity to avoid over‑spinning

## Testing
- `swiftc 3DBall/AppDelegate.swift -o /tmp/app` *(fails: no such module 'UIKit')*
- `swift package describe` *(fails: could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685807ef35e08328a29702f6dbf4f192