### PR TITLE
Add variable lanes and sloped ground

### DIFF
--- a/3DBall/GameViewController.swift
+++ b/3DBall/GameViewController.swift
@@ -105,8 +105,11 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate, SCNSceneR
         // velocity rather than continuously applying a force yields a
         // smoother result.
         if var velocity = ballNode.physicsBody?.velocity {
-            let targetSpeed: Float = -20
-            let accelerationPerSecond: Float = -30
+            // Slow the ball's forward movement so gameplay is more manageable.
+            // A lower target speed and gentler acceleration keep the pace fun
+            // without feeling frantic.
+            let targetSpeed: Float = -10
+            let accelerationPerSecond: Float = -15
 
             if velocity.z > targetSpeed {
                 velocity.z += accelerationPerSecond * Float(deltaTime)

--- a/3DBall/GameViewController.swift
+++ b/3DBall/GameViewController.swift
@@ -41,7 +41,7 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate, SCNSceneR
         setupCamera()
         setupBall()
         setupGround()
-        obstacleManager = ObstacleManager(scene: scene)
+        obstacleManager = ObstacleManager(scene: scene, groundManager: groundManager)
         setupGestures()
 
         // Use the view's renderer callback to update the game every frame.
@@ -138,6 +138,8 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate, SCNSceneR
             }
         }
 
+        let lanes = groundManager.lanePositions(for: ballNode.presentation.position.z)
+        ballNode.updateLanes(lanes)
         groundManager.update(for: ballNode.presentation.position.z)
         obstacleManager.update(for: ballNode.presentation.position.z, score: currentScore)
         environmentManager.update(position: ballNode.presentation.position)

--- a/3DBall/GroundManager.swift
+++ b/3DBall/GroundManager.swift
@@ -13,6 +13,8 @@ class GroundManager {
     private struct GroundTile {
         let node: SCNNode
         var lanePositions: [Float]
+        var slope: Float
+        var startY: Float
     }
 
     private(set) var tiles: [GroundTile] = []
@@ -51,15 +53,20 @@ class GroundManager {
         }()
         self.borderMaterial = borderMaterial
 
+        var currentY: Float = 0
         for i in 0..<5 {
-            let tile = createTile(zOffset: -Float(i) * tileLength)
+            let tile = createTile(startZ: -Float(i) * tileLength, startY: currentY)
             scene.rootNode.addChildNode(tile.node)
             tiles.append(tile)
+            currentY += sin(tile.slope) * tileLength
         }
     }
 
     /// Create a new ground tile with random width, lane layout and slope.
-    private func createTile(zOffset: Float) -> GroundTile {
+    /// - Parameters:
+    ///   - startZ: Z coordinate of the tile's front edge.
+    ///   - startY: Y coordinate where the tile begins (matching the previous tile's end).
+    private func createTile(startZ: Float, startY: Float) -> GroundTile {
         let laneCounts = [1, 2, 3, 5]
         let laneCount = laneCounts.randomElement() ?? 3
         let width = laneSpacing * Float(laneCount - 1) + 2.0
@@ -67,12 +74,15 @@ class GroundManager {
         let ground = SCNBox(width: CGFloat(width), height: 0.2, length: CGFloat(tileLength), chamferRadius: 0)
         ground.materials = [material]
         let groundNode = SCNNode(geometry: ground)
-        groundNode.position = SCNVector3(0, 0, zOffset)
+        // Pivot at the front edge so rotations keep the seam aligned.
+        groundNode.pivot = SCNMatrix4MakeTranslation(0, 0, Float(tileLength) / 2)
+        groundNode.position = SCNVector3(0, startY, startZ)
         groundNode.physicsBody = SCNPhysicsBody.static()
 
         // Random slope to create slide effect
         let slopes: [Float] = [0, 0.2, -0.2]
-        groundNode.eulerAngles.x = slopes.randomElement() ?? 0
+        let slope = slopes.randomElement() ?? 0
+        groundNode.eulerAngles.x = slope
 
         // Left and right borders
         let leftBorder = SCNBox(width: borderThickness, height: borderHeight, length: CGFloat(tileLength), chamferRadius: 0)
@@ -94,28 +104,29 @@ class GroundManager {
             lanes.append(startX + Float(i) * laneSpacing)
         }
 
-        return GroundTile(node: groundNode, lanePositions: lanes)
+        return GroundTile(node: groundNode, lanePositions: lanes, slope: slope, startY: startY)
     }
 
     /// Recycle tiles as the player moves forward and randomize their layout.
     func update(for playerZ: Float) {
-        for i in 0..<tiles.count {
-            if tiles[i].node.position.z - playerZ > 30 {
-                let newZ = tiles[i].node.position.z - Float(tiles.count) * tileLength
-                tiles[i].node.removeFromParentNode()
-                let newTile = createTile(zOffset: newZ)
-                scene.rootNode.addChildNode(newTile.node)
-                tiles[i] = newTile
-            }
+        while let first = tiles.first, first.node.position.z - playerZ > 30 {
+            let last = tiles.last!
+            let newZ = last.node.position.z - tileLength
+            let startY = last.startY + sin(last.slope) * tileLength
+            first.node.removeFromParentNode()
+            let newTile = createTile(startZ: newZ, startY: startY)
+            scene.rootNode.addChildNode(newTile.node)
+            tiles.removeFirst()
+            tiles.append(newTile)
         }
     }
 
     /// Lane positions for the segment at the specified Z coordinate.
     func lanePositions(for z: Float) -> [Float] {
         for tile in tiles {
-            let startZ = tile.node.position.z - tileLength
-            let endZ = tile.node.position.z
-            if z <= endZ && z > startZ {
+            let endZ = tile.node.position.z - tileLength
+            let startZ = tile.node.position.z
+            if z <= startZ && z > endZ {
                 return tile.lanePositions
             }
         }

--- a/3DBall/ObstacleManager.swift
+++ b/3DBall/ObstacleManager.swift
@@ -121,17 +121,17 @@ private enum ObstacleType: CaseIterable {
 class ObstacleManager {
     private var scene: SCNScene
     private var obstacles: [SCNNode] = []
-    private let lanes: [Float] = [-2, 0, 2]
+    private let ground: GroundManager
 
-    init(scene: SCNScene) {
+    init(scene: SCNScene, groundManager: GroundManager) {
         self.scene = scene
+        self.ground = groundManager
     }
 
     func spawnObstacle(atZ z: Float, score: Int) {
-        guard
-            let lane = lanes.randomElement(),
-            let type = ObstacleType.allCases.randomElement()
-        else { return }
+        guard let type = ObstacleType.allCases.randomElement() else { return }
+        let lanes = ground.lanePositions(for: z)
+        guard let lane = lanes.randomElement() else { return }
 
         guard let obstacle = type.createNode(score: score) else {
             // Wall gaps or other no-node obstacles

--- a/3DBall/PlayerNode.swift
+++ b/3DBall/PlayerNode.swift
@@ -2,7 +2,7 @@ import SceneKit
 
 class PlayerNode: SCNNode {
 
-    private let lanes: [Float] = [-2, 0, 2]
+    private var lanes: [Float] = [-2, 0, 2]
     private var currentLaneIndex: Int = 1
     private let moveSound: SCNAudioSource
 
@@ -49,6 +49,15 @@ class PlayerNode: SCNNode {
         if abs(self.presentation.position.y - 0.5) < 0.1 {
             self.physicsBody?.applyForce(SCNVector3(0, 4, 0), asImpulse: true)
         }
+    }
+
+    /// Update available lanes based on the current ground segment.
+    func updateLanes(_ newLanes: [Float]) {
+        lanes = newLanes
+        if currentLaneIndex >= lanes.count {
+            currentLaneIndex = lanes.count - 1
+        }
+        moveToCurrentLane()
     }
 
     func moveLeft() {


### PR DESCRIPTION
## Summary
- randomize ground tiles to have varying lane counts and slopes
- let PlayerNode receive lane updates from GroundManager
- update GameViewController and ObstacleManager to use the new lane info

## Testing
- `swiftc -parse 3DBall/*.swift`

------
https://chatgpt.com/codex/tasks/task_e_68592342f4288328a8a813684fc8bde0