### PR TITLE
Restore fixed-width ground

### DIFF
--- a/3DBall/GameViewController.swift
+++ b/3DBall/GameViewController.swift
@@ -41,7 +41,7 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate, SCNSceneR
         setupCamera()
         setupBall()
         setupGround()
-        obstacleManager = ObstacleManager(scene: scene, groundManager: groundManager)
+        obstacleManager = ObstacleManager(scene: scene)
         setupGestures()
 
         // Use the view's renderer callback to update the game every frame.
@@ -138,8 +138,6 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate, SCNSceneR
             }
         }
 
-        let lanes = groundManager.lanePositions(for: ballNode.presentation.position.z)
-        ballNode.updateLanes(lanes)
         groundManager.update(for: ballNode.presentation.position.z)
         obstacleManager.update(for: ballNode.presentation.position.z, score: currentScore)
         environmentManager.update(position: ballNode.presentation.position)

--- a/3DBall/GroundManager.swift
+++ b/3DBall/GroundManager.swift
@@ -9,24 +9,9 @@ import SceneKit
 
 class GroundManager {
 
-    /// Representation for a piece of ground with its lane layout.
-    private struct GroundTile {
-        let node: SCNNode
-        var lanePositions: [Float]
-    }
-
-    private var tiles: [GroundTile] = []
-
-    private let scene: SCNScene
-    private let material: SCNMaterial
-    private let borderMaterial: SCNMaterial
-    private let borderThickness: CGFloat = 0.2
-    private let borderHeight: CGFloat = 0.5
-    private let tileLength: Float = 20.0
-    private let laneSpacing: Float = 2.0
+    private(set) var tiles: [SCNNode] = []
 
     init(scene: SCNScene) {
-        self.scene = scene
         let material = SCNMaterial()
         if let image = UIImage(named: "ground") {
             material.diffuse.contents = image
@@ -36,7 +21,11 @@ class GroundManager {
         } else {
             material.diffuse.contents = UIColor.darkGray
         }
-        self.material = material
+
+        let roadWidth: CGFloat = 6.0
+        let tileLength: CGFloat = 20.0
+        let borderThickness: CGFloat = 0.2
+        let borderHeight: CGFloat = 0.5
 
         let borderMaterial: SCNMaterial = {
             let material = SCNMaterial()
@@ -49,77 +38,41 @@ class GroundManager {
             }
             return material
         }()
-        self.borderMaterial = borderMaterial
 
         for i in 0..<5 {
-            let tile = createTile(zOffset: -Float(i) * tileLength)
-            scene.rootNode.addChildNode(tile.node)
-            tiles.append(tile)
+            let ground = SCNBox(width: roadWidth, height: 0.2, length: tileLength, chamferRadius: 0)
+            ground.materials = [material]
+            let groundNode = SCNNode(geometry: ground)
+            groundNode.position = SCNVector3(0, 0, -Float(i) * Float(tileLength))
+            groundNode.physicsBody = SCNPhysicsBody.static()
+
+            // Left border rail
+            let leftBorder = SCNBox(width: borderThickness, height: borderHeight, length: tileLength, chamferRadius: 0)
+            leftBorder.firstMaterial?.diffuse.contents = UIColor.purple
+            leftBorder.firstMaterial = borderMaterial
+            let leftNode = SCNNode(geometry: leftBorder)
+            leftNode.position = SCNVector3(-Float(roadWidth / 2 + borderThickness / 2), Float(borderHeight / 2), 0)
+
+            // Right border rail
+            let rightBorder = SCNBox(width: borderThickness, height: borderHeight, length: tileLength, chamferRadius: 0)
+            rightBorder.firstMaterial?.diffuse.contents = UIColor.purple
+            rightBorder.firstMaterial = borderMaterial
+            let rightNode = SCNNode(geometry: rightBorder)
+            rightNode.position = SCNVector3(Float(roadWidth / 2 + borderThickness / 2), Float(borderHeight / 2), 0)
+
+            groundNode.addChildNode(leftNode)
+            groundNode.addChildNode(rightNode)
+
+            scene.rootNode.addChildNode(groundNode)
+            tiles.append(groundNode)
         }
     }
 
-    /// Create a new ground tile with random width, lane layout and slope.
-    private func createTile(zOffset: Float) -> GroundTile {
-        let laneCounts = [1, 2, 3, 5]
-        let laneCount = laneCounts.randomElement() ?? 3
-        let width = laneSpacing * Float(laneCount - 1) + 2.0
-
-        let ground = SCNBox(width: CGFloat(width), height: 0.2, length: CGFloat(tileLength), chamferRadius: 0)
-        ground.materials = [material]
-        let groundNode = SCNNode(geometry: ground)
-        groundNode.position = SCNVector3(0, 0, zOffset)
-        groundNode.physicsBody = SCNPhysicsBody.static()
-
-        // Random slope to create slide effect
-        let slopes: [Float] = [0, 0.2, -0.2]
-        groundNode.eulerAngles.x = slopes.randomElement() ?? 0
-
-        // Left and right borders
-        let leftBorder = SCNBox(width: borderThickness, height: borderHeight, length: CGFloat(tileLength), chamferRadius: 0)
-        leftBorder.firstMaterial = borderMaterial
-        let leftNode = SCNNode(geometry: leftBorder)
-        leftNode.position = SCNVector3(-width / 2 - Float(borderThickness) / 2, Float(borderHeight / 2), 0)
-
-        let rightBorder = SCNBox(width: borderThickness, height: borderHeight, length: CGFloat(tileLength), chamferRadius: 0)
-        rightBorder.firstMaterial = borderMaterial
-        let rightNode = SCNNode(geometry: rightBorder)
-        rightNode.position = SCNVector3(width / 2 + Float(borderThickness) / 2, Float(borderHeight / 2), 0)
-
-        groundNode.addChildNode(leftNode)
-        groundNode.addChildNode(rightNode)
-
-        var lanes: [Float] = []
-        let startX = -laneSpacing * Float(laneCount - 1) / 2
-        for i in 0..<laneCount {
-            lanes.append(startX + Float(i) * laneSpacing)
-        }
-
-        return GroundTile(node: groundNode, lanePositions: lanes)
-    }
-
-    /// Recycle tiles as the player moves forward and randomize their layout.
     func update(for playerZ: Float) {
-        for i in 0..<tiles.count {
-            if tiles[i].node.position.z - playerZ > 30 {
-                let newZ = tiles[i].node.position.z - Float(tiles.count) * tileLength
-                tiles[i].node.removeFromParentNode()
-                let newTile = createTile(zOffset: newZ)
-                scene.rootNode.addChildNode(newTile.node)
-                tiles[i] = newTile
-            }
-        }
-    }
-
-    /// Lane positions for the segment at the specified Z coordinate.
-    func lanePositions(for z: Float) -> [Float] {
         for tile in tiles {
-            let startZ = tile.node.position.z - tileLength
-            let endZ = tile.node.position.z
-            if z <= endZ && z > startZ {
-                return tile.lanePositions
+            if tile.position.z - playerZ > 30 {
+                tile.position.z -= 100
             }
         }
-        // Fallback to first tile's lanes
-        return tiles.first?.lanePositions ?? [-2, 0, 2]
     }
 }

--- a/3DBall/ObstacleManager.swift
+++ b/3DBall/ObstacleManager.swift
@@ -121,17 +121,17 @@ private enum ObstacleType: CaseIterable {
 class ObstacleManager {
     private var scene: SCNScene
     private var obstacles: [SCNNode] = []
-    private let ground: GroundManager
+    private let lanes: [Float] = [-2, 0, 2]
 
-    init(scene: SCNScene, groundManager: GroundManager) {
+    init(scene: SCNScene) {
         self.scene = scene
-        self.ground = groundManager
     }
 
     func spawnObstacle(atZ z: Float, score: Int) {
-        guard let type = ObstacleType.allCases.randomElement() else { return }
-        let lanes = ground.lanePositions(for: z)
-        guard let lane = lanes.randomElement() else { return }
+        guard
+            let lane = lanes.randomElement(),
+            let type = ObstacleType.allCases.randomElement()
+        else { return }
 
         guard let obstacle = type.createNode(score: score) else {
             // Wall gaps or other no-node obstacles

--- a/3DBall/PlayerNode.swift
+++ b/3DBall/PlayerNode.swift
@@ -2,7 +2,7 @@ import SceneKit
 
 class PlayerNode: SCNNode {
 
-    private var lanes: [Float] = [-2, 0, 2]
+    private let lanes: [Float] = [-2, 0, 2]
     private var currentLaneIndex: Int = 1
     private let moveSound: SCNAudioSource
 
@@ -49,15 +49,6 @@ class PlayerNode: SCNNode {
         if abs(self.presentation.position.y - 0.5) < 0.1 {
             self.physicsBody?.applyForce(SCNVector3(0, 4, 0), asImpulse: true)
         }
-    }
-
-    /// Update available lanes based on the current ground segment.
-    func updateLanes(_ newLanes: [Float]) {
-        lanes = newLanes
-        if currentLaneIndex >= lanes.count {
-            currentLaneIndex = lanes.count - 1
-        }
-        moveToCurrentLane()
     }
 
     func moveLeft() {


### PR DESCRIPTION
## Summary
- revert GroundManager to constant 3-lane road
- remove dynamic lane logic from player and obstacle manager
- simplify game update loop accordingly

## Testing
- `swiftc 3DBall/PlayerNode.swift -o /tmp/player.out` *(fails: no such module 'SceneKit')*

------
https://chatgpt.com/codex/tasks/task_e_6859321698c08328bdeb84ef860e79d3