### PR TITLE
Dynamic lane switching for ground transition

### DIFF
--- a/3DBall/GameViewController.swift
+++ b/3DBall/GameViewController.swift
@@ -41,7 +41,7 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate, SCNSceneR
         setupCamera()
         setupBall()
         setupGround()
-        obstacleManager = ObstacleManager(scene: scene)
+        obstacleManager = ObstacleManager(scene: scene, groundManager: groundManager)
         setupGestures()
 
         // Use the view's renderer callback to update the game every frame.
@@ -137,6 +137,10 @@ class GameViewController: UIViewController, SCNPhysicsContactDelegate, SCNSceneR
                 ballNode.physicsBody?.velocity = velocity
             }
         }
+
+        // Update the player's lane layout based on the ground beneath it
+        let lanes = groundManager.lanePositions(for: ballNode.presentation.position.z)
+        ballNode.updateLanePositions(lanes)
 
         groundManager.update(for: ballNode.presentation.position.z)
         obstacleManager.update(for: ballNode.presentation.position.z, score: currentScore)

--- a/3DBall/ObstacleManager.swift
+++ b/3DBall/ObstacleManager.swift
@@ -121,15 +121,17 @@ private enum ObstacleType: CaseIterable {
 class ObstacleManager {
     private var scene: SCNScene
     private var obstacles: [SCNNode] = []
-    private let lanes: [Float] = [-2, 0, 2]
+    private let groundManager: GroundManager
 
-    init(scene: SCNScene) {
+    init(scene: SCNScene, groundManager: GroundManager) {
         self.scene = scene
+        self.groundManager = groundManager
     }
 
     func spawnObstacle(atZ z: Float, score: Int) {
+        let laneOptions = groundManager.lanePositions(for: z)
         guard
-            let lane = lanes.randomElement(),
+            let lane = laneOptions.randomElement(),
             let type = ObstacleType.allCases.randomElement()
         else { return }
 

--- a/3DBall/PlayerNode.swift
+++ b/3DBall/PlayerNode.swift
@@ -2,7 +2,9 @@ import SceneKit
 
 class PlayerNode: SCNNode {
 
-    private let lanes: [Float] = [-2, 0, 2]
+    /// Current lane layout used for lateral movement. This is updated by the
+    /// game controller each frame based on the ground manager.
+    private var lanes: [Float] = [-2, 0, 2]
     private var currentLaneIndex: Int = 1
     private let moveSound: SCNAudioSource
 
@@ -63,6 +65,19 @@ class PlayerNode: SCNNode {
         currentLaneIndex += 1
         moveToCurrentLane()
         playMoveSound()
+    }
+
+    /// Update the current lane layout. This keeps the player centered on the
+    /// lane closest to its current X position when the number of lanes changes.
+    func updateLanePositions(_ newLanes: [Float]) {
+        lanes = newLanes
+        // Find the lane index closest to the current X coordinate
+        let currentX = presentation.position.x
+        if let index = lanes.enumerated().min(by: { abs($0.element - currentX) < abs($1.element - currentX) })?.offset {
+            currentLaneIndex = index
+        } else {
+            currentLaneIndex = min(currentLaneIndex, lanes.count - 1)
+        }
     }
 
     private func playMoveSound() {


### PR DESCRIPTION
## Summary
- allow PlayerNode to handle variable lane layouts
- synchronize lane layout each frame in GameViewController
- pass GroundManager to ObstacleManager so obstacles spawn in correct lanes

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685936239b708328918c937e5fd09e9a